### PR TITLE
Fix high-degree Chebyshev barycentric interpolation

### DIFF
--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -2,7 +2,7 @@
     LagrangePolynomials{T}
 
 Barycentric Lagrange basis over a grid of type `T`. Stores the grid nodes and the
-pre-computed barycentric weights so that each basis function can be evaluated in O(K) time.
+pre-computed scaled barycentric weights so that each basis function can be evaluated in O(K) time.
 """
 struct LagrangePolynomials{T}
     grid::Vector{T}
@@ -10,11 +10,30 @@ struct LagrangePolynomials{T}
 end
 
 function (P::LagrangePolynomials{T})(alpha::Int, x::T)::T where {T}
-    if abs(x - P.grid[alpha + 1]) >= 1.0e-14
-        return prod(x .- P.grid) * P.baryweights[alpha + 1] / (x - P.grid[alpha + 1])
-    else
+    if alpha < 0 || alpha >= length(P.grid)
+        throw(BoundsError(P.grid, alpha + 1))
+    end
+    if !isfinite(x)
+        throw(ArgumentError("basis evaluation point must be finite"))
+    end
+
+    tol = T(1.0e-14)
+    if abs(x - P.grid[alpha + 1]) < tol
         return one(T)
     end
+    if any(node -> abs(x - node) < tol, P.grid)
+        return zero(T)
+    end
+
+    denominator = zero(T)
+    for j in eachindex(P.grid)
+        denominator += P.baryweights[j] / (x - P.grid[j])
+    end
+    if iszero(denominator) || !isfinite(denominator)
+        throw(ArgumentError("barycentric denominator must be finite and non-zero"))
+    end
+
+    return (P.baryweights[alpha + 1] / (x - P.grid[alpha + 1])) / denominator
 end
 
 """
@@ -24,12 +43,17 @@ Return a `LagrangePolynomials` object built on the `K+1` Chebyshev nodes of the 
 kind mapped to `[0, 1]`, together with their barycentric weights.
 """
 function getChebyshevGrid(K::Int)::LagrangePolynomials{Float64}
+    K >= 1 || throw(ArgumentError("polynomial degree must be at least 1"))
     chebgrid = 0.5 * (1.0 .- cospi.((0:K) / K))
-    baryweights = [
-        prod(j == m ? 1.0 : 1.0 / (chebgrid[j + 1] - chebgrid[m + 1]) for m in 0:K)
+    baryweights = _chebyshev_lobatto_baryweights(K)
+    return LagrangePolynomials{Float64}(chebgrid, baryweights)
+end
+
+function _chebyshev_lobatto_baryweights(K::Int)::Vector{Float64}
+    return [
+        (j == 0 || j == K ? 0.5 : 1.0) * (isodd(j) ? -1.0 : 1.0)
             for j in 0:K
     ]
-    return LagrangePolynomials{Float64}(chebgrid, baryweights)
 end
 
 function interpolationtensor(P::LagrangePolynomials{Float64})

--- a/test/test_interpolation.jl
+++ b/test/test_interpolation.jl
@@ -162,6 +162,33 @@ end
     @test vec(c123) ≈ vec(c123_ref)
 end
 
+@testset "high-degree Chebyshev basis stays finite" begin
+    K = 600
+    P = InterpolativeQTT.getChebyshevGrid(K)
+
+    @test length(P.grid) == K + 1
+    @test all(isfinite, P.baryweights)
+    @test P(0, P.grid[1]) ≈ 1.0
+    @test P(1, P.grid[1]) ≈ 0.0 atol = 1.0e-12
+
+    A = InterpolativeQTT.interpolationtensor(P)
+    @test all(isfinite, A)
+end
+
+@testset "high-degree single-scale interpolation remains accurate" begin
+    R = 3
+    K = 600
+    f(x) = sin(2 * π * x)
+
+    tt = InterpolativeQTT.interpolatesinglescale(f, 0.0, 1.0, R, K)
+    grid = QG.DiscretizedGrid{1}(R, 0.0, 1.0)
+    quanticsinds = QG.grididx_to_quantics.(Ref(grid), 1:(2^R))
+    xs = QG.grididx_to_origcoord.(Ref(grid), 1:(2^R))
+    maxerr = maximum(abs.(tt.(quanticsinds) .- f.(xs)))
+
+    @test maxerr < 1.0e-10
+end
+
 
 @testset "multiscale interpolation (1/x)" begin
     R = 12


### PR DESCRIPTION
## Summary

This applies the same high-degree Chebyshev-Lobatto barycentric stabilization as tensor4all-rs PR tensor4all/tensor4all-rs#530.

The previous implementation built barycentric weights with a direct product of node differences and evaluated each basis function with the product-form Lagrange formula. At degree 600 this overflows to non-finite weights, produces a non-finite interpolation core, and later fails in LAPACK/SVD.

This PR:

- uses the closed-form scaled Chebyshev-Lobatto barycentric weights
- evaluates the basis with the second barycentric formula
- preserves exact node handling for cardinal basis values
- adds degree-600 regression tests for finite weights/core entries and QTT interpolation accuracy

## Reproduction Data

Before the fix on `main`:

```text
K=600
finite_weights=0/601
finite_core=6/722402
interpolatesinglescale(sin(2πx), 0.0, 1.0, R=20, K=600)
ERROR ArgumentError: ArgumentError("invalid argument #4 to LAPACK call")
```

After the fix:

```text
interpolatesinglescale(sin(2πx), 0.0, 1.0, R=20, K=600)
OK length=20
max_abs_err=8.548717289613705e-15 at grid index 331897
```

The new smaller CI regression (`R=3, K=600`) reports:

```text
maxerr = 3.78101430010869e-15
```

## Validation

```text
julia --project=. -e 'using InterpolativeQTT, QuanticsGrids, Test; ... high-degree checks ...'
julia --project=. -e 'using Pkg; Pkg.test()'
julia --project=docs docs/make.jl
```

## References

- tensor4all-rs companion PR: tensor4all/tensor4all-rs#530
- Berrut & Trefethen, “Barycentric Lagrange Interpolation”: https://people.maths.ox.ac.uk/trefethen/barycentric.pdf
- Webb, Trefethen & Gonnet, “Stability of Barycentric Interpolation Formulas”: https://personalpages.manchester.ac.uk/staff/marcus.webb/pdfs/webbbarycentric.pdf
- Chebfun Guide, Chebyshev approximation/interpolants: https://www.chebfun.org/docs/guide/guide04.html
